### PR TITLE
changed cd hardhat command to cd subgraph in NFT-Marketplace-Part-2.m…

### DIFF
--- a/NFT-Marketplace-Part-2.md
+++ b/NFT-Marketplace-Part-2.md
@@ -70,11 +70,11 @@ Run the following command in your terminal, from the `subgraph` directory:
 
 ```shell
 # Linux / macOS
-cd hardhat
+cd subgraph
 rm -rf .git
 
 # Windows
-cd hardhat
+cd subgraph
 rmdir /s /q .git
 ```
 

--- a/NFT-Marketplace-Part-3.md
+++ b/NFT-Marketplace-Part-3.md
@@ -282,7 +282,7 @@ export default function Listing(props) {
   async function fetchNFTDetails() {
     try {
       // Get token URI from contract
-      let tokenURI = await ERC721Contract.tokenURI(0);
+      let tokenURI = await ERC721Contract.tokenURI(props.tokenId);
       // If it's an IPFS URI, replace it with an HTTP Gateway link
       tokenURI = tokenURI.replace("ipfs://", "https://ipfs.io/ipfs/");
 


### PR DESCRIPTION
In the NFTMarketplace-Part-2.md file to remove the .git file that is auto generated by the graph we are using the command 
* `cd hardhat`  &&  `rm  -rf  .git`
* but it has to be changed to `cd subgraph`  because the .git will be generated in the subgraph folder