### PR TITLE
Typo in commands of NFT-Marketplace-Part-2.md

### DIFF
--- a/NFT-Marketplace-Part-2.md
+++ b/NFT-Marketplace-Part-2.md
@@ -70,11 +70,9 @@ Run the following command in your terminal, from the `subgraph` directory:
 
 ```shell
 # Linux / macOS
-cd hardhat
 rm -rf .git
 
 # Windows
-cd hardhat
 rmdir /s /q .git
 ```
 


### PR DESCRIPTION
Typo in commands for removing .git from subgraph directory. 