### PR TITLE
Updating ERC721Contract Instance

### DIFF
--- a/NFT-Marketplace-Part-3.md
+++ b/NFT-Marketplace-Part-3.md
@@ -270,8 +270,8 @@ export default function Listing(props) {
   const provider = useProvider();
   const { address } = useAccount();
   const ERC721Contract = useContract({
-    addressOrName: props.nftAddress,
-    contractInterface: erc721ABI,
+    address: props.nftAddress,
+    abi: erc721ABI,
     signerOrProvider: provider,
   });
 


### PR DESCRIPTION
Previously the contract instance was defined as this:
```js
const ERC721Contract = useContract({
    addressOrName: props.nftAddress,
    contractInterface: erc721ABI,
    signerOrProvider: provider,
  });
```
This would come out as undefined

It is now changed to this:
```js
const ERC721Contract = useContract({
    address: props.nftAddress,
    abi: erc721ABI,
    signerOrProvider: provider,
  });
```
```